### PR TITLE
Modify to use q2b indices when training kbc

### DIFF
--- a/kbc/process_datasets.py
+++ b/kbc/process_datasets.py
@@ -4,21 +4,18 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
-import pkg_resources
+import argparse
 import os
 import errno
 import shutil
-from pathlib import Path
 import pickle
 
 import numpy as np
 
 from collections import defaultdict
 
-DATA_PATH = pkg_resources.resource_filename('kbc', 'data/')
 
-
-def prepare_dataset(path, name):
+def prepare_dataset(path):
     """
     Given a path to a folder containing tab separated files :
      train, test, valid
@@ -29,70 +26,102 @@ def prepare_dataset(path, name):
     Also create to_skip_lhs / to_skip_rhs for filtered metrics and
     rel_id / ent_id for analysis.
     """
-    files = ['train', 'valid', 'test']
-    entities, relations = set(), set()
-    for f in files:
-        file_path = os.path.join(path, f)
-        to_read = open(file_path, 'r')
-        for line in to_read.readlines():
-            lhs, rel, rhs = line.strip().split('\t')
-            entities.add(lhs)
-            entities.add(rhs)
-            relations.add(rel)
-        to_read.close()
+    out_path = os.path.join(path, 'kbc_data')
+    files = ['train.txt', 'valid.txt', 'test.txt']
 
-    entities_to_id = {x: i for (i, x) in enumerate(sorted(entities))}
-    relations_to_id = {x: i for (i, x) in enumerate(sorted(relations))}
-    print("{} entities and {} relations".format(len(entities), len(relations)))
-    n_relations = len(relations)
-    n_entities = len(entities)
+    q2b_maps = ['ind2ent.pkl', 'ind2rel.pkl']
+    if all([os.path.exists(os.path.join(path, f)) for f in q2b_maps]):
+        # Read IDs from q2b mappings
+        with open(os.path.join(path, q2b_maps[0]), 'rb') as f:
+            ind2ent = pickle.load(f)
+            entities_to_id = {ent: i for i, ent in ind2ent.items()}
+        with open(os.path.join(path, q2b_maps[1]), 'rb') as f:
+            ind2rel = pickle.load(f)
+            relations_to_id = {rel: i for i, rel in ind2rel.items()}
 
-    if os.path.exists(os.path.join(DATA_PATH, name)):
-        shutil.rmtree(os.path.join(DATA_PATH, name))
+        # Create IDs for the remaining entities and relations (not used in q2b)
+        max_ent_id = max(entities_to_id.values())
+        max_rel_id = max(relations_to_id.values())
 
-    os.makedirs(os.path.join(DATA_PATH, name))
+        for f in files:
+            file_path = os.path.join(path, f)
+            with open(file_path, 'r') as to_read:
+                for line in to_read.readlines():
+                    lhs, rel, rhs = line.strip().split('\t')
+                    if lhs not in entities_to_id:
+                        max_ent_id += 1
+                        entities_to_id[lhs] = max_ent_id
+                    if rhs not in entities_to_id:
+                        max_ent_id += 1
+                        entities_to_id[rhs] = max_ent_id
+                    if rel not in relations_to_id:
+                        max_rel_id += 1
+                        relations_to_id[rel] = max_rel_id
+
+    else:
+        entities, relations = set(), set()
+        for f in files:
+            file_path = os.path.join(path, f)
+            with open(file_path, 'r') as to_read:
+                for line in to_read.readlines():
+                    lhs, rel, rhs = line.strip().split('\t')
+                    entities.add(lhs)
+                    entities.add(rhs)
+                    relations.add(rel)
+
+        entities_to_id = {x: i for (i, x) in enumerate(sorted(entities))}
+        relations_to_id = {x: i for (i, x) in enumerate(sorted(relations))}
+
+    n_relations = len(relations_to_id)
+    n_entities = len(entities_to_id)
+    print(f'{n_entities} entities and {n_relations} relations')
+
+    if os.path.exists(out_path):
+        shutil.rmtree(out_path)
+
+    os.makedirs(out_path)
     # write ent to id / rel to id
     for (dic, f) in zip([entities_to_id, relations_to_id], ['ent_id', 'rel_id']):
-        ff = open(os.path.join(DATA_PATH, name, f), 'w+')
-        for (x, i) in dic.items():
-            ff.write("{}\t{}\n".format(x, i))
-        ff.close()
+        pickle.dump(dic, open(os.path.join(out_path, f'{f}.pickle'), 'wb'))
 
     # map train/test/valid with the ids
+    to_skip = {'lhs': defaultdict(set), 'rhs': defaultdict(set)}
     for f in files:
         file_path = os.path.join(path, f)
         to_read = open(file_path, 'r')
         examples = []
         for line in to_read.readlines():
             lhs, rel, rhs = line.strip().split('\t')
-            try:
-                examples.append([entities_to_id[lhs], relations_to_id[rel], entities_to_id[rhs]])
-            except ValueError:
-                continue
-        out = open(Path(DATA_PATH) / name / (f + '.pickle'), 'wb')
+
+            lhs_id = entities_to_id[lhs]
+            rhs_id = entities_to_id[rhs]
+            rel_id = relations_to_id[rel]
+            inv_rel_id = relations_to_id[rel + '_reverse']
+
+            examples.append([lhs_id, rel_id, rhs_id])
+            to_skip['rhs'][(lhs_id, rel_id)].add(rhs_id)
+            to_skip['lhs'][(rhs_id, inv_rel_id)].add(lhs_id)
+
+            # Add inverse relations for training
+            if f == 'train.txt':
+                examples.append([rhs_id, inv_rel_id, lhs_id])
+                to_skip['rhs'][(rhs_id, inv_rel_id)].add(lhs_id)
+                to_skip['lhs'][(lhs_id, rel_id)].add(rhs_id)
+
+        out = open(os.path.join(out_path, f + '.pickle'), 'wb')
         pickle.dump(np.array(examples).astype('uint64'), out)
         out.close()
-
-    print("creating filtering lists")
-
-    # create filtering files
-    to_skip = {'lhs': defaultdict(set), 'rhs': defaultdict(set)}
-    for f in files:
-        examples = pickle.load(open(Path(DATA_PATH) / name / (f + '.pickle'), 'rb'))
-        for lhs, rel, rhs in examples:
-            to_skip['lhs'][(rhs, rel + n_relations)].add(lhs)  # reciprocals
-            to_skip['rhs'][(lhs, rel)].add(rhs)
 
     to_skip_final = {'lhs': {}, 'rhs': {}}
     for kk, skip in to_skip.items():
         for k, v in skip.items():
             to_skip_final[kk][k] = sorted(list(v))
 
-    out = open(Path(DATA_PATH) / name / 'to_skip.pickle', 'wb')
+    out = open(os.path.join(out_path, 'to_skip.pickle'), 'wb')
     pickle.dump(to_skip_final, out)
     out.close()
 
-    examples = pickle.load(open(Path(DATA_PATH) / name / 'train.pickle', 'rb'))
+    examples = pickle.load(open(os.path.join(out_path, 'train.txt.pickle'), 'rb'))
     counters = {
         'lhs': np.zeros(n_entities),
         'rhs': np.zeros(n_entities),
@@ -106,25 +135,27 @@ def prepare_dataset(path, name):
         counters['both'][rhs] += 1
     for k, v in counters.items():
         counters[k] = v / np.sum(v)
-    out = open(Path(DATA_PATH) / name / 'probas.pickle', 'wb')
+    out = open(os.path.join(out_path, 'probas.pickle'), 'wb')
     pickle.dump(counters, out)
     out.close()
 
 
 if __name__ == "__main__":
-    datasets = ['FB15K', 'WN', 'WN18RR', 'FB237', 'YAGO3-10', "Bio"]
-    for d in datasets:
-        print("Preparing dataset {}".format(d))
-        try:
-            prepare_dataset(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)), 'src_data', d
-                ),
-                d
-            )
-        except OSError as e:
-            if e.errno == errno.EEXIST:
-                print(e)
-                print("File exists. skipping...")
-            else:
-                raise
+
+    parser = argparse.ArgumentParser(
+        description="Relational learning contraption"
+    )
+    parser.add_argument('data_path', help='Path containing triples for'
+                                            ' training, validation, and test')
+    args = parser.parse_args()
+    data_path = args.data_path
+
+    print(f'Loading dataset from {data_path}')
+    try:
+        prepare_dataset(data_path)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            print(e)
+            print("File exists. skipping...")
+        else:
+            raise


### PR DESCRIPTION
I modified `process_datasets.py` to receive a dataset path. The path should correspond to a folder containing the train, validation, and test triples in their original form (e.g. Freebase identifiers), and the q2b pickled dictionaries that map the numeric entity id to the original identifier (`ind2ent.pkl` and `ind2rel.pkl`). So roughly the directory should look like

```
FB15k-237/
- train.txt
- valid.txt
- test.txt
- ind2ent.pkl
- ind2rel.pkl
```

I also had to modify `datasets.py` because in q2b relations and their inverses are added one after the other (rel1, rel1inv, ...) whereas in the original KBC all normal relations would go first, and then there would be a second group with the inverses.